### PR TITLE
Import existing VPC infrastructure into Terraform management

### DIFF
--- a/.github/workflows/terraform-import.yml
+++ b/.github/workflows/terraform-import.yml
@@ -1,0 +1,93 @@
+name: terraform-import-aws-resource
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ '*' ]
+    paths:
+      - 'terraform-import-aws-resource/**'
+  pull_request:
+    branches: ["main"]
+    paths:
+      - 'terraform-import-aws-resource/**'
+
+permissions: read-all
+
+jobs:
+  terraform:
+    name: 'terraform-import'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
+    defaults:
+      run:
+        shell: bash
+        working-directory: ./terraform-import-aws-resource
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Configure AWS Credentials Action For GitHub Actions
+      uses: aws-actions/configure-aws-credentials@v1-node16
+      with:
+        role-to-assume: ${{ secrets.IAM_ROLE }}
+        role-session-name: AWSSession
+        aws-region: us-west-2
+
+    - name: Setup Terraform
+      uses: hashicorp/setup-terraform@v1
+
+    - name: Terraform Init
+      id: init
+      run: terraform init
+
+    - name: Terraform Format
+      id: fmt
+      run: terraform fmt -check
+
+    - name: Terraform Validate
+      id: validate
+      run: terraform validate -no-color
+
+    - name: Terraform Plan
+      id: plan
+      if: github.ref != 'refs/heads/main' || github.event_name == 'pull_request'
+      run: terraform plan -no-color -input=false
+      continue-on-error: true
+
+    - name: Post Terraform Plan Output
+      uses: actions/github-script@v6
+      if: github.event_name == 'pull_request'
+      env:
+        PLAN: "terraform\n${{ steps.plan.outputs.stdout }}"
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          const output = `#### Terraform Format and Style 🖌\`${{ steps.fmt.outcome }}\`
+          #### Terraform Initialization ⚙️\`${{ steps.init.outcome }}\`
+          #### Terraform Plan 📖\`${{ steps.plan.outcome }}\`
+          #### Terraform Validation 🤖\`${{ steps.validate.outcome }}\`
+
+          <details><summary>Show Plan</summary>
+
+          \`\`\`\n
+          ${process.env.PLAN}
+          \`\`\`
+
+          </details>
+
+          *Pushed by: @${{ github.actor }}, Action: \`${{ github.event_name }}\`*`;
+
+          github.rest.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: output
+          })
+
+    - name: Terraform Apply
+      if: github.ref == 'refs/heads/main'
+      run: terraform apply -auto-approve -input=false -no-color

--- a/.github/workflows/terraform-import.yml
+++ b/.github/workflows/terraform-import.yml
@@ -11,6 +11,8 @@ on:
     paths:
       - 'terraform-import-aws-resource/**'
 
+env:
+  AWS_REGION: us-west-2  # set this to your preferred AWS region
 permissions: read-all
 
 jobs:
@@ -31,14 +33,14 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Configure AWS Credentials Action For GitHub Actions
-      uses: aws-actions/configure-aws-credentials@v1-node16
+      uses: aws-actions/configure-aws-credentials@v5.1.0
       with:
         role-to-assume: ${{ secrets.IAM_ROLE }}
         role-session-name: AWSSession
-        aws-region: us-west-2
+        aws-region: ${{ env.AWS_REGION }}
 
     - name: Setup Terraform
-      uses: hashicorp/setup-terraform@v1
+      uses: hashicorp/setup-terraform@v3
 
     - name: Terraform Init
       id: init

--- a/.github/workflows/terraform-import.yml
+++ b/.github/workflows/terraform-import.yml
@@ -6,10 +6,12 @@ on:
     branches: [ '*' ]
     paths:
       - 'terraform-import-aws-resource/**'
+      - '.github/workflows/terraform-import.yml'
   pull_request:
     branches: ["main"]
     paths:
       - 'terraform-import-aws-resource/**'
+      - '.github/workflows/terraform-import.yml'
 
 env:
   AWS_REGION: us-west-2  # set this to your preferred AWS region

--- a/.github/workflows/terraform-import.yml
+++ b/.github/workflows/terraform-import.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Configure AWS Credentials Action For GitHub Actions
       uses: aws-actions/configure-aws-credentials@v5.1.0

--- a/terraform-import-aws-resource/backend.tf
+++ b/terraform-import-aws-resource/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket       = "kunduso-terraform-remote-bucket"
+    encrypt      = true
+    key          = "tf/learn-terraform/terraform-import-aws-resource/terraform.tfstate"
+    region       = "us-east-2"
+    use_lockfile = true
+  }
+}

--- a/terraform-import-aws-resource/main.tf
+++ b/terraform-import-aws-resource/main.tf
@@ -1,12 +1,12 @@
 # Import block for existing VPC
 import {
   to = aws_vpc.imported_vpc
-  id = "vpc-09b1634a885c02134"
+  id = "vpc-070e2d49d3100f46d"
 }
 
 # VPC resource configuration to match the manually created VPC
 resource "aws_vpc" "imported_vpc" {
-  cidr_block           = "10.0.0.0/24"
+  cidr_block           = "12.25.15.0/25"
   enable_dns_hostnames = true
   enable_dns_support   = true
 

--- a/terraform-import-aws-resource/main.tf
+++ b/terraform-import-aws-resource/main.tf
@@ -29,7 +29,7 @@ import {
 # Public subnet resources
 resource "aws_subnet" "web_tier_public_1" {
   vpc_id            = aws_vpc.imported_vpc.id
-  cidr_block        = "12.25.15.0/27" # You'll need to verify this CIDR
+  cidr_block        = "12.25.15.0/27"
   availability_zone = "us-west-2a"
 
   tags = {
@@ -39,7 +39,7 @@ resource "aws_subnet" "web_tier_public_1" {
 
 resource "aws_subnet" "web_tier_public_2" {
   vpc_id            = aws_vpc.imported_vpc.id
-  cidr_block        = "12.25.15.32/27" # You'll need to verify this CIDR
+  cidr_block        = "12.25.15.32/27"
   availability_zone = "us-west-2b"
 
   tags = {
@@ -60,7 +60,7 @@ import {
 # Private subnet resources
 resource "aws_subnet" "web_tier_private_1" {
   vpc_id            = aws_vpc.imported_vpc.id
-  cidr_block        = "12.25.15.64/27" # You'll need to verify this CIDR
+  cidr_block        = "12.25.15.64/27"
   availability_zone = "us-west-2a"
 
   tags = {
@@ -70,7 +70,7 @@ resource "aws_subnet" "web_tier_private_1" {
 
 resource "aws_subnet" "web_tier_private_2" {
   vpc_id            = aws_vpc.imported_vpc.id
-  cidr_block        = "12.25.15.96/27" # You'll need to verify this CIDR
+  cidr_block        = "12.25.15.96/27"
   availability_zone = "us-west-2b"
 
   tags = {

--- a/terraform-import-aws-resource/main.tf
+++ b/terraform-import-aws-resource/main.tf
@@ -46,3 +46,34 @@ resource "aws_subnet" "web_tier_public_2" {
     Name = "web-tier-public-2"
   }
 }
+# Import blocks for private subnets
+import {
+  to = aws_subnet.web_tier_private_1
+  id = "subnet-06b929c181ad6c4ff"
+}
+
+import {
+  to = aws_subnet.web_tier_private_2
+  id = "subnet-07838fbfa5c1efc17"
+}
+
+# Private subnet resources
+resource "aws_subnet" "web_tier_private_1" {
+  vpc_id            = aws_vpc.imported_vpc.id
+  cidr_block        = "12.25.15.64/27" # You'll need to verify this CIDR
+  availability_zone = "us-west-2a"
+
+  tags = {
+    Name = "web-tier-private-1"
+  }
+}
+
+resource "aws_subnet" "web_tier_private_2" {
+  vpc_id            = aws_vpc.imported_vpc.id
+  cidr_block        = "12.25.15.96/27" # You'll need to verify this CIDR
+  availability_zone = "us-west-2b"
+
+  tags = {
+    Name = "web-tier-private-2"
+  }
+}

--- a/terraform-import-aws-resource/main.tf
+++ b/terraform-import-aws-resource/main.tf
@@ -141,20 +141,20 @@ resource "aws_route_table_association" "web_tier_private_2" {
 # Import blocks for route table associations
 import {
   to = aws_route_table_association.web_tier_public_1
-  id = "rtbassoc-078b958640daabc73"
+  id = "subnet-0ea4fe97c34c804e6/rtb-0051b74c62960239a"
 }
 
 import {
   to = aws_route_table_association.web_tier_public_2
-  id = "rtbassoc-0f66b46d503af04be"
+  id = "subnet-05b20b4d8660a2bd4/rtb-0051b74c62960239a"
 }
 
 import {
   to = aws_route_table_association.web_tier_private_1
-  id = "rtbassoc-0dda10d372e1c2814"
+  id = "subnet-06b929c181ad6c4ff/rtb-096262c0795386cb0"
 }
 
 import {
   to = aws_route_table_association.web_tier_private_2
-  id = "rtbassoc-0da23891815279cb8"
+  id = "subnet-07838fbfa5c1efc17/rtb-066e3d20ee79c434a"
 }

--- a/terraform-import-aws-resource/main.tf
+++ b/terraform-import-aws-resource/main.tf
@@ -6,7 +6,7 @@ import {
 
 # VPC resource configuration to match the manually created VPC
 resource "aws_vpc" "imported_vpc" {
-  cidr_block           = "10.0.0.0/16"
+  cidr_block           = "10.0.0.0/24"
   enable_dns_hostnames = true
   enable_dns_support   = true
 

--- a/terraform-import-aws-resource/main.tf
+++ b/terraform-import-aws-resource/main.tf
@@ -1,0 +1,16 @@
+# Import block for existing VPC
+import {
+  to = aws_vpc.imported_vpc
+  id = "vpc-09b1634a885c02134"
+}
+
+# VPC resource configuration to match the manually created VPC
+resource "aws_vpc" "imported_vpc" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = {
+    Name = "import-vpc"
+  }
+}

--- a/terraform-import-aws-resource/main.tf
+++ b/terraform-import-aws-resource/main.tf
@@ -29,7 +29,7 @@ import {
 # Public subnet resources
 resource "aws_subnet" "web_tier_public_1" {
   vpc_id            = aws_vpc.imported_vpc.id
-  cidr_block        = "12.25.15.0/27"  # You'll need to verify this CIDR
+  cidr_block        = "12.25.15.0/27" # You'll need to verify this CIDR
   availability_zone = "us-west-2a"
 
   tags = {
@@ -39,7 +39,7 @@ resource "aws_subnet" "web_tier_public_1" {
 
 resource "aws_subnet" "web_tier_public_2" {
   vpc_id            = aws_vpc.imported_vpc.id
-  cidr_block        = "12.25.15.32/27"  # You'll need to verify this CIDR
+  cidr_block        = "12.25.15.32/27" # You'll need to verify this CIDR
   availability_zone = "us-west-2b"
 
   tags = {

--- a/terraform-import-aws-resource/main.tf
+++ b/terraform-import-aws-resource/main.tf
@@ -14,3 +14,35 @@ resource "aws_vpc" "imported_vpc" {
     Name = "web-tier"
   }
 }
+
+# Import blocks for public subnets
+import {
+  to = aws_subnet.web_tier_public_1
+  id = "subnet-0ea4fe97c34c804e6"
+}
+
+import {
+  to = aws_subnet.web_tier_public_2
+  id = "subnet-05b20b4d8660a2bd4"
+}
+
+# Public subnet resources
+resource "aws_subnet" "web_tier_public_1" {
+  vpc_id            = aws_vpc.imported_vpc.id
+  cidr_block        = "12.25.15.0/27"  # You'll need to verify this CIDR
+  availability_zone = "us-west-2a"
+
+  tags = {
+    Name = "web-tier-public-1"
+  }
+}
+
+resource "aws_subnet" "web_tier_public_2" {
+  vpc_id            = aws_vpc.imported_vpc.id
+  cidr_block        = "12.25.15.32/27"  # You'll need to verify this CIDR
+  availability_zone = "us-west-2b"
+
+  tags = {
+    Name = "web-tier-public-2"
+  }
+}

--- a/terraform-import-aws-resource/main.tf
+++ b/terraform-import-aws-resource/main.tf
@@ -11,6 +11,6 @@ resource "aws_vpc" "imported_vpc" {
   enable_dns_support   = true
 
   tags = {
-    Name = "import-vpc"
+    Name = "web-tier"
   }
 }

--- a/terraform-import-aws-resource/main.tf
+++ b/terraform-import-aws-resource/main.tf
@@ -77,3 +77,64 @@ resource "aws_subnet" "web_tier_private_2" {
     Name = "web-tier-private-2"
   }
 }
+# Import blocks for route tables
+import {
+  to = aws_route_table.web_tier_public
+  id = "rtb-0051b74c62960239a"
+}
+
+import {
+  to = aws_route_table.web_tier_private_1
+  id = "rtb-096262c0795386cb0"
+}
+
+import {
+  to = aws_route_table.web_tier_private_2
+  id = "rtb-066e3d20ee79c434a"
+}
+
+# Route table resources
+resource "aws_route_table" "web_tier_public" {
+  vpc_id = aws_vpc.imported_vpc.id
+
+  tags = {
+    Name = "web-tier-public"
+  }
+}
+
+resource "aws_route_table" "web_tier_private_1" {
+  vpc_id = aws_vpc.imported_vpc.id
+
+  tags = {
+    Name = "web-tier-private-1"
+  }
+}
+
+resource "aws_route_table" "web_tier_private_2" {
+  vpc_id = aws_vpc.imported_vpc.id
+
+  tags = {
+    Name = "web-tier-private-2"
+  }
+}
+
+# Route table associations
+resource "aws_route_table_association" "web_tier_public_1" {
+  subnet_id      = aws_subnet.web_tier_public_1.id
+  route_table_id = aws_route_table.web_tier_public.id
+}
+
+resource "aws_route_table_association" "web_tier_public_2" {
+  subnet_id      = aws_subnet.web_tier_public_2.id
+  route_table_id = aws_route_table.web_tier_public.id
+}
+
+resource "aws_route_table_association" "web_tier_private_1" {
+  subnet_id      = aws_subnet.web_tier_private_1.id
+  route_table_id = aws_route_table.web_tier_private_1.id
+}
+
+resource "aws_route_table_association" "web_tier_private_2" {
+  subnet_id      = aws_subnet.web_tier_private_2.id
+  route_table_id = aws_route_table.web_tier_private_2.id
+}

--- a/terraform-import-aws-resource/main.tf
+++ b/terraform-import-aws-resource/main.tf
@@ -138,3 +138,23 @@ resource "aws_route_table_association" "web_tier_private_2" {
   subnet_id      = aws_subnet.web_tier_private_2.id
   route_table_id = aws_route_table.web_tier_private_2.id
 }
+# Import blocks for route table associations
+import {
+  to = aws_route_table_association.web_tier_public_1
+  id = "rtbassoc-078b958640daabc73"
+}
+
+import {
+  to = aws_route_table_association.web_tier_public_2
+  id = "rtbassoc-0f66b46d503af04be"
+}
+
+import {
+  to = aws_route_table_association.web_tier_private_1
+  id = "rtbassoc-0dda10d372e1c2814"
+}
+
+import {
+  to = aws_route_table_association.web_tier_private_2
+  id = "rtbassoc-0da23891815279cb8"
+}

--- a/terraform-import-aws-resource/provider.tf
+++ b/terraform-import-aws-resource/provider.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.16.0"
+      version = "~> 6.16"
     }
   }
 }

--- a/terraform-import-aws-resource/provider.tf
+++ b/terraform-import-aws-resource/provider.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "6.16.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}

--- a/terraform-import-aws-resource/variables.tf
+++ b/terraform-import-aws-resource/variables.tf
@@ -1,0 +1,6 @@
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-west-2"
+}
+

--- a/terraform-import-aws-resource/variables.tf
+++ b/terraform-import-aws-resource/variables.tf
@@ -1,5 +1,5 @@
 variable "aws_region" {
-  description = "AWS region"
+  description = "AWS region where the VPC infrastructure will be imported and managed"
   type        = string
   default     = "us-west-2"
 }


### PR DESCRIPTION
This PR implements the complete solution for importing existing AWS VPC infrastructure into Terraform state using declarative import blocks.

## Changes Made
- Added Terraform configuration for VPC, subnets, route tables, and associations
- Configured import blocks for all 12 AWS resources
- Set up S3 backend for remote state management
- Created GitHub Actions workflow for automated Terraform operations

## Resources Imported
- 1 VPC (vpc-070e2d49d3100f46d)
- 4 subnets (2 public, 2 private)
- 3 route tables
- 4 route table associations

## Validation
- terraform plan shows 12 to import, 0 to add, 0 to change, 0 to destroy
- All CIDR blocks and configurations match existing AWS resources
- No configuration drift detected

Closes #4
Closes #5
Closes #6